### PR TITLE
Fix Route53 resource creation error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,9 @@ test:
 test-race:
 	go test -race -timeout 60s -v ./...
 
+test-ci:
+	act -l
+	act -n
+
 build: fmt lint
 	rm -f bin/${APPLICATION} && env GOOS=${GOOS} GOARCH=${GOARCH} go build -o bin/${APPLICATION}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # webup
+This is a simple cli tool to make it easier to prepare s3 bucket for websitehosting.
+## How to create a s3 buckt ready for webhosting.
+
+```
+webup create -n www.testwebsite.devops.lk
+Starting to set up bucket
+2022/01/30 16:22:40 Bucket created www.testwebsite.devops.lk
+2022/01/30 16:22:41 DNS created www.testwebsite.devops.lk
+```

--- a/aws/r53_dns.go
+++ b/aws/r53_dns.go
@@ -11,6 +11,10 @@ import (
 	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 )
 
+//S3WebSiteEndPointEuCentral1 is the s3 endpoint for eu-central-1
+//s3-website.eu-central-1.amazonaws.com
+const S3WebSiteEndPointEuCentral1 = ".s3-website.eu-central-1.amazonaws.com"
+
 // R53API defines the interface for the CreateHostedZone function.
 // We use this interface to test the function using a mocked service.
 type R53API interface {
@@ -49,8 +53,9 @@ func NewR53Client() (*r53.Client, error) {
 //    s3 website endpoint (https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints)
 //    dns name of the website
 //    dns zone id
-func MakeRoutes(c context.Context, client R53API, s3websiteendpoint, dnsname, zoneid string) (string, error) {
-
+// example endpoint http://www.testwebsite.devops.lk.s3-website.eu-central-1.amazonaws.com
+func MakeRoutes(c context.Context, client R53API, dnsname, zoneid string) (string, error) {
+	s3websiteendpoint := dnsname + S3WebSiteEndPointEuCentral1
 	input := &r53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &r53types.ChangeBatch{
 			Changes: []r53types.Change{

--- a/aws/r53_dns_test.go
+++ b/aws/r53_dns_test.go
@@ -19,7 +19,7 @@ func (dt R53APIImpl) ChangeResourceRecordSets(ctx context.Context,
 	optFns ...func(*r53.Options)) (*r53.ChangeResourceRecordSetsOutput, error) {
 
 	output := &r53.ChangeResourceRecordSetsOutput{
-		ChangeInfo: &r53types.ChangeInfo{},
+		ChangeInfo:     &r53types.ChangeInfo{},
 		ResultMetadata: middleware.Metadata{},
 	}
 
@@ -29,7 +29,7 @@ func (dt R53APIImpl) ChangeResourceRecordSets(ctx context.Context,
 
 func TestMakeRoutes(t *testing.T) {
 	api := &R53APIImpl{}
-	_, err := MakeRoutes(context.TODO(), api, "s3-website-eu-west-1.amazonaws.com", "abc-test.com", "Z1TI4H711TUAOG")
+	_, err := MakeRoutes(context.TODO(), api, "abc-test.com", "Z1TI4H711TUAOG")
 	if err != nil {
 		fmt.Println("failed")
 	}

--- a/aws/s3_test.go
+++ b/aws/s3_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/smithy-go/middleware"
 	"github.com/stretchr/testify/assert"
 )
+
 // S3BucketImpl is for implementing testable s3 client without calling aws services
 type S3BucketImpl struct{}
 
@@ -40,7 +41,7 @@ func (dt S3BucketImpl) PutBucketWebsite(ctx context.Context,
 func TestMakeBucket(t *testing.T) {
 	api := &S3BucketImpl{}
 
-	_,err := MakeBucket(context.TODO(), api, "abc.com")
+	_, err := MakeBucket(context.TODO(), api, "abc.com")
 	if err != nil {
 		fmt.Println("failed")
 	}

--- a/aws/webresources.go
+++ b/aws/webresources.go
@@ -25,7 +25,7 @@ func MakeWebResources(c context.Context, webSiteName string) error {
 		log.Fatal(err)
 		return errors.New("Could not create s3 bucket")
 	}
-	log.Println("Bucket created" + bucket)
+	log.Printf("Bucket %s created \n", bucket)
 
 	// creates a R53 client
 	r53client, err := NewR53Client()
@@ -36,13 +36,13 @@ func MakeWebResources(c context.Context, webSiteName string) error {
 	}
 
 	// create route53 rules
-	dns, err := MakeRoutes(c, r53client, "s3-website-eu-west-1.amazonaws.com", webSiteName, "Z1TI4H711TUGO5")
+	dns, err := MakeRoutes(c, r53client, webSiteName, "Z1TI4H711TUGO5")
 	if err != nil {
 		log.Println("Error setting up s3 bucket")
 		log.Fatal(err)
 		return errors.New("Could not create s3 bucket")
 	}
-	log.Println("DNS created" + dns)
+	log.Printf("DNS %s created ", dns)
 
 	return nil
 }

--- a/aws/webresources_test.go
+++ b/aws/webresources_test.go
@@ -18,13 +18,13 @@ func TestMakeWebResources(t *testing.T) {
 	// creates s3 bucket and setup bucket for webhosting
 	bucket, err := MakeBucket(context.TODO(), s3client, "abc.com")
 	assert.Nil(t, err)
-	assert.Equal(t, "abc.com", bucket )
+	assert.Equal(t, "abc.com", bucket)
 
 	// creates a r53 client
 	r53client := &R53APIImpl{}
 
 	// create route53 rules
-	dns, err := MakeRoutes(context.TODO(), r53client, "s3-website-eu-west-1.amazonaws.com", "abc-test.com", "Z1TI4H711TUAOG")
+	dns, err := MakeRoutes(context.TODO(), r53client, "abc-test.com", "Z1TI4H711TUAOG")
 	assert.Nil(t, err)
 	assert.Equal(t, "abc-test.com", dns)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -16,11 +16,12 @@ var createCmd = &cobra.Command{
 	Short: "Creates a new website in AWS",
 	Long:  `Creates a new website for the given dns name.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("create called")
+		fmt.Println("Starting to set up bucket")
 		err := aws.MakeWebResources(context.TODO(), webSiteName)
 		if err != nil {
 			fmt.Println("failed")
 		}
+		fmt.Println("Done setting up bucket")
 	},
 }
 


### PR DESCRIPTION
- route53 resource creation error fixed

```
2022/01/30 16:21:20 operation error Route 53: ChangeResourceRecordSets, https response error StatusCode: 400, RequestID: ff296a77-cce3-45e8-8868-2b5a151beb39, InvalidChangeBatch: [Tried to create an alias that targets www.amilak87testwebsite2.devops.lks3-website.eu-central-1.amazonaws.com., type A in zone Z21DNDUVLTQW6Q, but the alias target name does not lie within the target zone]
```

output after fix:

```
./bin/webup create -n www.amilak87testwebsite4.devops.lk
Creating bucket resources
2022/01/30 16:22:40 Bucket createdwww.amilak87testwebsite4.devops.lk
2022/01/30 16:22:41 DNS createdwww.amilak87testwebsite4.devops.lk
Done
```